### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,11 +7,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 env:
   GOLANG_VERSION: '1.24'
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/SergK/tkn-graph/security/code-scanning/1](https://github.com/SergK/tkn-graph/security/code-scanning/1)

To fix the issue, we will add the `permissions` key at the root of the workflow file. This ensures that all jobs inherit the least privilege permissions required. Based on the tasks performed in the workflow (e.g., checkout, building/testing, and SonarCloud scanning), it appears that no write operations are needed. We will set `contents: read` to limit the `GITHUB_TOKEN` to read-only access. If future requirements necessitate write access for specific operations, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
